### PR TITLE
replaced solc with docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -22,13 +22,10 @@ ADD . /explorer
 RUN npm install -g @angular/cli@7.2.1
 RUN make frontend
 
-FROM ethereum/solc:stable as solc
-
 FROM alpine:latest
 WORKDIR /explorer
-RUN apk add --no-cache ca-certificates
+RUN apk add --no-cache ca-certificates docker
 COPY --from=backend_builder /tmp/gochain/* /usr/local/bin/
-COPY --from=solc /usr/bin/solc /usr/local/bin/
 COPY --from=frontend_builder /explorer/dist/* /explorer/
 
 EXPOSE 8080

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -2,11 +2,13 @@ version: "3"
 services:
   web:
     container_name: web
-    image: gcr.io/gochain-core/explorer:go-test
+    image: gcr.io/gochain-core/explorer:latest
     restart: "always"
     command: "server -d /explorer/ -m mongodb:27017"
     links:
         - "mongodb"
+    volumes:
+        - "/var/run/docker.sock:/var/run/docker.sock"
     ports:
         - "80:8080"
         - "8080:8080"
@@ -14,7 +16,7 @@ services:
       - mongodb    
   grabber:
     container_name: grabber
-    image: gcr.io/gochain-core/explorer:go-test
+    image: gcr.io/gochain-core/explorer:latest
     restart: "always"
     command: "grabber -m mongodb:27017"
     links:

--- a/server/backend/backend.go
+++ b/server/backend/backend.go
@@ -11,7 +11,6 @@ import (
 
 	"github.com/gochain-io/explorer/server/models"
 	"github.com/gochain-io/gochain/v3/common"
-	"github.com/gochain-io/gochain/v3/common/compiler"
 	"github.com/gochain-io/gochain/v3/core/types"
 	"github.com/gochain-io/gochain/v3/goclient"
 	"github.com/rs/zerolog/log"
@@ -158,7 +157,7 @@ func (self *Backend) VerifyContract(contractData *models.Contract) (*models.Cont
 		err := errors.New("contract with given address is already verified")
 		return nil, err
 	}
-	compileData, err := compiler.CompileSolidityString("solc", contractData.SourceCode)
+	compileData, err := CompileSolidityString(contractData.SourceCode)
 	if err != nil {
 		err := errors.New("error occurred while compiling source code")
 		return nil, err
@@ -196,17 +195,6 @@ func (self *Backend) VerifyContract(contractData *models.Contract) (*models.Cont
 		err := errors.New("the compiled result does not match the input creation bytecode located at " + contractData.Address)
 		return nil, err
 	}
-}
-
-func (self *Backend) GetCompilerVersion() (string, error) {
-	result, err := compiler.SolidityVersion("solc")
-	if err != nil {
-		err := errors.New("error occurred while processing")
-		return "", err
-	}
-	versionRegexp := regexp.MustCompile(`([0-9]+)\.([0-9]+)\.([0-9]+)\+commit\.[^.]*`)
-	longVersion := versionRegexp.FindStringSubmatch(result.FullVersion)
-	return longVersion[0], nil
 }
 
 //METHODS USED IN GRABBER

--- a/server/backend/backend.go
+++ b/server/backend/backend.go
@@ -147,7 +147,7 @@ func (self *Backend) GetBlockByHash(hash string) *models.Block {
 	return self.mongo.getBlockByHash(hash)
 }
 
-func (self *Backend) VerifyContract(contractData *models.Contract) (*models.Contract, error) {
+func (self *Backend) VerifyContract(ctx context.Context, contractData *models.Contract) (*models.Contract, error) {
 	contract := self.GetContract(contractData.Address)
 	if contract == nil {
 		err := errors.New("contract with given address not found")
@@ -157,8 +157,9 @@ func (self *Backend) VerifyContract(contractData *models.Contract) (*models.Cont
 		err := errors.New("contract with given address is already verified")
 		return nil, err
 	}
-	compileData, err := CompileSolidityString(contractData.SourceCode)
+	compileData, err := CompileSolidityString(ctx, contractData.SourceCode)
 	if err != nil {
+		log.Error().Err(err).Msg("error while compilation")
 		err := errors.New("error occurred while compiling source code")
 		return nil, err
 	}

--- a/server/backend/dockerhub_api.go
+++ b/server/backend/dockerhub_api.go
@@ -7,30 +7,30 @@ import (
 	"time"
 )
 
+type DockerHubAPI struct {
+	lastUpdatedSolcAt    time.Time
+	cachedListOfSolcTags []string
+}
+
 const dockerHubUrl = "https://registry.hub.docker.com"
 
 type Tag struct {
 	Name string
 }
 
-var (
-	LastUpdatedAt    time.Time
-	CachedListOfTags []string
-)
-
-func GetSolcImageTags() ([]string, error) {
-	duration := time.Since(LastUpdatedAt)
+func (api *DockerHubAPI) GetSolcImageTags() ([]string, error) {
+	duration := time.Since(api.lastUpdatedSolcAt)
 	if int(duration.Hours()) < 1 {
-		return CachedListOfTags, nil
+		return api.cachedListOfSolcTags, nil
 	}
 	//update the list of the tags every hour
 	tags, err := GetImageTags("ethereum/solc")
 	if err != nil {
 		return nil, err
 	}
-	LastUpdatedAt = time.Now()
-	CachedListOfTags = tags
-	return CachedListOfTags, nil
+	api.lastUpdatedSolcAt = time.Now()
+	api.cachedListOfSolcTags = tags
+	return api.cachedListOfSolcTags, nil
 }
 
 func GetImageTags(imageFullName string) (tags []string, err error) {
@@ -46,7 +46,7 @@ func GetImageTags(imageFullName string) (tags []string, err error) {
 
 func filterTags(tags []Tag) (res []string) {
 	for _, elem := range tags {
-		if !(strings.Contains(elem.Name, "alpine") || elem.Name == "stable") {
+		if !(strings.Contains(elem.Name, "alpine") || elem.Name == "stable" || elem.Name == "nightly") {
 			res = append(res, elem.Name)
 		}
 	}

--- a/server/backend/dockerhub_api.go
+++ b/server/backend/dockerhub_api.go
@@ -1,0 +1,67 @@
+package backend
+
+import (
+	"encoding/json"
+	"net/http"
+	"strings"
+	"time"
+)
+
+const dockerHubUrl = "https://registry.hub.docker.com"
+
+type Tag struct {
+	Name string
+}
+
+var (
+	LastUpdatedAt    time.Time
+	CachedListOfTags []string
+)
+
+func GetSolcImageTags() ([]string, error) {
+	duration := time.Since(LastUpdatedAt)
+	if int(duration.Hours()) < 1 {
+		return CachedListOfTags, nil
+	}
+	//update the list of the tags every hour
+	tags, err := GetImageTags("ethereum/solc")
+	if err != nil {
+		return nil, err
+	}
+	LastUpdatedAt = time.Now()
+	CachedListOfTags = tags
+	return CachedListOfTags, nil
+}
+
+func GetImageTags(imageFullName string) (tags []string, err error) {
+	url := dockerHubUrl + "/v1/repositories/" + imageFullName + "/tags"
+	var response []Tag
+	err = parseJson(url, &response)
+	if err != nil {
+		return nil, err
+	}
+	tags = append(tags, filterTags(response)...)
+	return tags, nil
+}
+
+func filterTags(tags []Tag) (res []string) {
+	for _, elem := range tags {
+		if !(strings.Contains(elem.Name, "alpine") || elem.Name == "stable") {
+			res = append(res, elem.Name)
+		}
+	}
+	return res
+}
+func parseJson(url string, response interface{}) error {
+	resp, err := http.Get(url)
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+	decoder := json.NewDecoder(resp.Body)
+	err = decoder.Decode(response)
+	if err != nil {
+		return err
+	}
+	return nil
+}

--- a/server/backend/solc.go
+++ b/server/backend/solc.go
@@ -1,6 +1,7 @@
 package backend
 
 import (
+	"bufio"
 	"bytes"
 	"context"
 	"encoding/json"
@@ -73,7 +74,9 @@ func (s *Solidity) makeArgs() ([]string, error) {
 // SolidityVersion scan the source code and parse the version from pragma attribute
 func SolidityVersion(source string) (*Solidity, error) {
 	var err error
-	for _, line := range strings.Split(source, "\n") {
+	scanner := bufio.NewScanner(strings.NewReader(source))
+	for scanner.Scan() {
+		line := scanner.Text()
 		if strings.HasPrefix(strings.TrimSpace(line), "pragma solidity") {
 			matches := versionRegexp.FindStringSubmatch(line)
 			if len(matches) != 4 {

--- a/server/backend/solc.go
+++ b/server/backend/solc.go
@@ -1,0 +1,167 @@
+package backend
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"os"
+	"os/exec"
+	"regexp"
+	"strconv"
+	"strings"
+)
+
+var versionRegexp = regexp.MustCompile(`([0-9]+)\.([0-9]+)\.([0-9]+)`)
+
+// Contract contains information about a compiled contract, alongside its code and runtime code.
+type Contract struct {
+	Code        string       `json:"code"`
+	RuntimeCode string       `json:"runtime-code"`
+	Info        ContractInfo `json:"info"`
+}
+
+// ContractInfo contains information about a compiled contract, including access
+// to the ABI definition, source mapping, user and developer docs, and metadata.
+//
+// Depending on the source, language version, compiler version, and compiler
+// options will provide information about how the contract was compiled.
+type ContractInfo struct {
+	Source          string      `json:"source"`
+	Language        string      `json:"language"`
+	LanguageVersion string      `json:"languageVersion"`
+	CompilerVersion string      `json:"compilerVersion"`
+	CompilerOptions string      `json:"compilerOptions"`
+	SrcMap          string      `json:"srcMap"`
+	SrcMapRuntime   string      `json:"srcMapRuntime"`
+	AbiDefinition   interface{} `json:"abiDefinition"`
+	UserDoc         interface{} `json:"userDoc"`
+	DeveloperDoc    interface{} `json:"developerDoc"`
+	Metadata        string      `json:"metadata"`
+}
+
+// Solidity contains information about the solidity compiler.
+type Solidity struct {
+	Path, Version, FullVersion string
+	Major, Minor, Patch        int
+}
+
+// --combined-output format
+type solcOutput struct {
+	Contracts map[string]struct {
+		BinRuntime                                  string `json:"bin-runtime"`
+		SrcMapRuntime                               string `json:"srcmap-runtime"`
+		Bin, SrcMap, Abi, Devdoc, Userdoc, Metadata string
+	}
+	Version string
+}
+
+func (s *Solidity) makeArgs() ([]string, error) {
+	dir, err := os.Getwd()
+	if err != nil {
+		return nil, err
+	}
+	return []string{
+		"run", "-i", "-v", dir + ":/workdir", "-w", "/workdir", "ethereum/solc:" + strconv.Itoa(s.Major) + "." + strconv.Itoa(s.Minor) + "." + strconv.Itoa(s.Patch),
+		"--combined-json",
+		"bin,bin-runtime,srcmap,srcmap-runtime,abi,userdoc,devdoc,metadata",
+		"--optimize", // code optimizer switched on
+	}, nil
+}
+
+// SolidityVersion runs solc and parses its version output.
+func SolidityVersion(source string) (*Solidity, error) {
+	var err error
+	matches := versionRegexp.FindStringSubmatch(source)
+	if len(matches) != 4 {
+		return nil, fmt.Errorf("can't parse solc version %q", source)
+	}
+	s := &Solidity{Path: "docker", FullVersion: "", Version: matches[0]}
+	if s.Major, err = strconv.Atoi(matches[1]); err != nil {
+		return nil, err
+	}
+	if s.Minor, err = strconv.Atoi(matches[2]); err != nil {
+		return nil, err
+	}
+	if s.Patch, err = strconv.Atoi(matches[3]); err != nil {
+		return nil, err
+	}
+	return s, nil
+}
+
+// CompileSolidityString builds and returns all the contracts contained within a source string.
+func CompileSolidityString(source string) (map[string]*Contract, error) {
+	if len(source) == 0 {
+		return nil, errors.New("solc: empty source string")
+	}
+	s, err := SolidityVersion(source)
+	if err != nil {
+		return nil, err
+	}
+	args, err := s.makeArgs()
+	if err != nil {
+		return nil, err
+	}
+	args = append(args, "--")
+	cmd := exec.CommandContext(context.Background(), s.Path, append(args, "-")...)
+	cmd.Stdin = strings.NewReader(source)
+	return s.run(cmd, source)
+}
+
+func (s *Solidity) run(cmd *exec.Cmd, source string) (map[string]*Contract, error) {
+	var stderr, stdout bytes.Buffer
+	cmd.Stderr = &stderr
+	cmd.Stdout = &stdout
+	if err := cmd.Run(); err != nil {
+		return nil, fmt.Errorf("solc: %v\n%s", err, stderr.Bytes())
+	}
+	args, err := s.makeArgs()
+	if err != nil {
+		return nil, err
+	}
+	return ParseCombinedJSON(stdout.Bytes(), source, s.Version, s.Version, strings.Join(args, " "))
+}
+
+func ParseCombinedJSON(combinedJSON []byte, source string, languageVersion string, compilerVersion string, compilerOptions string) (map[string]*Contract, error) {
+	var output solcOutput
+	if err := json.Unmarshal(combinedJSON, &output); err != nil {
+		return nil, err
+	}
+
+	// Compilation succeeded, assemble and return the contracts.
+	contracts := make(map[string]*Contract)
+	for name, info := range output.Contracts {
+		// Parse the individual compilation results.
+		var abi interface{}
+		if err := json.Unmarshal([]byte(info.Abi), &abi); err != nil {
+			return nil, fmt.Errorf("solc: error reading abi definition (%v)", err)
+		}
+		var userdoc interface{}
+		if err := json.Unmarshal([]byte(info.Userdoc), &userdoc); err != nil {
+			return nil, fmt.Errorf("solc: error reading user doc: %v", err)
+		}
+		var devdoc interface{}
+		if err := json.Unmarshal([]byte(info.Devdoc), &devdoc); err != nil {
+			return nil, fmt.Errorf("solc: error reading dev doc: %v", err)
+		}
+		contracts[name] = &Contract{
+			Code:        "0x" + info.Bin,
+			RuntimeCode: "0x" + info.BinRuntime,
+			Info: ContractInfo{
+				Source:          source,
+				Language:        "Solidity",
+				LanguageVersion: languageVersion,
+				CompilerVersion: compilerVersion,
+				CompilerOptions: compilerOptions,
+				SrcMap:          info.SrcMap,
+				SrcMapRuntime:   info.SrcMapRuntime,
+				AbiDefinition:   abi,
+				UserDoc:         userdoc,
+				DeveloperDoc:    devdoc,
+				Metadata:        info.Metadata,
+			},
+		}
+	}
+	return contracts, nil
+}

--- a/server/main.go
+++ b/server/main.go
@@ -347,7 +347,7 @@ func verifyContract(w http.ResponseWriter, r *http.Request) {
 		errorResponse(w, http.StatusBadRequest, err)
 		return
 	}*/
-	result, err := backendInstance.VerifyContract(contractData)
+	result, err := backendInstance.VerifyContract(r.Context(), contractData)
 	if err != nil {
 		errorResponse(w, http.StatusBadRequest, err)
 		return

--- a/server/main.go
+++ b/server/main.go
@@ -188,7 +188,6 @@ func main() {
 		})
 		r.Route("/api", func(r chi.Router) {
 			r.Post("/verify", verifyContract)
-			r.Get("/compiler", getCompilerVersion)
 		})
 		r.Route("/api/transaction", func(r chi.Router) {
 			r.Get("/{hash}", getTransaction)
@@ -354,15 +353,6 @@ func verifyContract(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	writeJSON(w, http.StatusAccepted, result)
-}
-
-func getCompilerVersion(w http.ResponseWriter, r *http.Request) {
-	result, err := backendInstance.GetCompilerVersion()
-	if err != nil {
-		errorResponse(w, http.StatusBadRequest, err)
-		return
-	}
-	writeJSON(w, http.StatusOK, result)
 }
 
 func getListBlocks(w http.ResponseWriter, r *http.Request) {

--- a/src/app/scenes/contract/contract.component.html
+++ b/src/app/scenes/contract/contract.component.html
@@ -10,10 +10,7 @@
 </p>
 <p>
   If the compiled bytecode matches the Creation Address bytecode, the contract is then Verified and will be published
-  online.
-</p>
-<p>
-  Compiler version: {{compilerVersion$ | async}}
+  online. (to build a contract you should either use <a href="https://github.com/gochain-io/web3#build-a-smart-contract">web3 tool</a> or set the version of the solc compiler in the contract source header using a 'pragma solidity' tag)
 </p>
 
 <form class="uk-form-horizontal" [formGroup]="form" (submit)="onSubmit()">

--- a/src/app/scenes/contract/contract.component.html
+++ b/src/app/scenes/contract/contract.component.html
@@ -26,7 +26,7 @@
       <input class="uk-input" type="text" placeholder="" formControlName="contract_name">
     </div>
   </div>
-  <!--<div class="uk-margin">
+  <div class="uk-margin">
     <label class="uk-form-label" for="form-horizontal-select">Compiler*</label>
     <div class="uk-form-controls">
       <select class="uk-select" id="form-horizontal-select" formControlName="compiler_version">
@@ -34,7 +34,7 @@
         <option *ngFor="let compiler of compilers">{{compiler}}</option>
       </select>
     </div>
-  </div>-->
+  </div>
   <!--<div class="uk-margin">
     <div class="uk-form-label">Optimization*</div>
     <div class="uk-form-controls uk-form-controls-text">

--- a/src/app/scenes/contract/contract.component.ts
+++ b/src/app/scenes/contract/contract.component.ts
@@ -29,14 +29,15 @@ export class ContractComponent implements OnInit {
   form: FormGroup = this._fb.group({
     address: ['', Validators.required, Validators.minLength(42), Validators.maxLength(42)],
     contract_name: ['', Validators.required],
+    compiler_version: ['', Validators.required],
     // optimization: [true, Validators.required],
     source_code: ['', Validators.required],
     /*recaptcha_token: null,*/
   });
 
-  // compiler_version: ['', Validators.required],
+  
   // abi: [''],
-  // compilers: any[] = [];
+  compilers: any[] = [];
 
   private _subsArr$: Subscription[] = [];
 
@@ -45,15 +46,9 @@ export class ContractComponent implements OnInit {
               private contactService: ContractService,
               private toastrService: ToastrService,
               private _router: Router) {
-    /*this.contactService.getCompilersList().subscribe((value: any) => {
-      this.compilers = value.builds.map((item: Compiler) => {
-        if (item.prerelease && item.prerelease.length > 0) {
-          return item.version + '-' + item.prerelease + '+' +  item.build;
-        } else {
-          return item.version;
-        }
-      }).reverse();
-    });*/
+    this.contactService.getCompilersList().subscribe((value: any) => {
+      this.compilers = value;
+    });
   }
 
   ngOnInit() {

--- a/src/app/scenes/contract/contract.component.ts
+++ b/src/app/scenes/contract/contract.component.ts
@@ -22,8 +22,7 @@ import {ROUTES} from '../../utils/constants';
   styleUrls: ['./contract.component.scss']
 })
 @AutoUnsubscribe('_subsArr$')
-export class ContractComponent implements OnInit {
-  compilerVersion$: Observable<string> = this.contactService.getCompilerVersion();
+export class ContractComponent implements OnInit {  
   contract: Contract;
   /*recaptchaPublicKey = environment.RECAPTCHA_KEY;*/
 

--- a/src/app/services/contract.service.ts
+++ b/src/app/services/contract.service.ts
@@ -24,7 +24,4 @@ export class ContractService {
     return this._apiService.post('/verify', data);
   }
 
-  getCompilerVersion() {
-    return this._apiService.get('/compiler');
-  }
 }

--- a/src/app/services/contract.service.ts
+++ b/src/app/services/contract.service.ts
@@ -17,7 +17,7 @@ export class ContractService {
   }
 
   getCompilersList() {
-    return this.http.get('https://ethereum.github.io/solc-bin/bin/list.json');
+    return this._apiService.get('/compiler');
   }
 
   compile(data: any) {


### PR DESCRIPTION
Replaced solc binary with docker image call, should be much easier to use web3 to compile and deploy or set the specific solc version in the sol header (not sure that selecting version from the list is a good idea - there are tons of versions - https://hub.docker.com/r/ethereum/solc/tags)