### PR TITLE
add 'v' tag prefix for go mod compatibility

### DIFF
--- a/release.sh
+++ b/release.sh
@@ -27,9 +27,9 @@ echo "Version: $version"
 docker build . -t $user/$image
 git add -u
 git commit -m "$image: $version release [skip ci]"
-git tag -f -a "$version" -m "version $version"
+git tag -f -a "v$version" -m "version $version"
 git push
-git push origin $version
+git push origin v$version
 
 # Finally, push docker images
 docker tag $user/$image:latest $user/$image:$version


### PR DESCRIPTION
This PR adds a `v` prefix to the release tags so to go modules will recognize them correctly.