### PR TITLE
Fix ng missing running "make frontend"

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -20,6 +20,6 @@ frontend:
 	node patch.js
 	rm -rf dist/explorer
 	npm rebuild node-sass
-	ng build --prod
+	./node_modules/@angular/cli/bin/ng build --prod
 
 build: backend frontend


### PR DESCRIPTION
There is an error running "make build" or "make frontend" due to ng not being present in PATH. This modification fixes that issue creating a correct frontend component. 

Before this fix we were getting: 
```
ng build --prod
make: ng: No such file or directory
make: *** [frontend] Error 1
```

Now it compiles correctly: 
```
./node_modules/@angular/cli/bin/ng build --prod

Date: 2019-05-25T19:13:47.801Z
Hash: fe39881071c803eb9a8b
Time: 43187ms
chunk {0} runtime.dbe60396b2b6a7b0b81e.js (runtime) 2.14 kB [entry] [rendered]
chunk {1} main.b6c18873ea484a1e7b15.js (main) 1.57 MB [initial] [rendered]
chunk {2} polyfills.f1469bb599048845cc26.js (polyfills) 63.8 kB [initial] [rendered]
chunk {3} styles.289196ceb6631b741505.css (styles) 7.95 kB [initial] [rendered]
chunk {4} 4.eb6724193b354dac2ff3.js () 80.6 kB  [rendered]
```

and generates the correct frontend component. 